### PR TITLE
Release/v0.3.0 beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@actions/core": "^1.10.1",
         "@slack/web-api": "^7.3.1",
         "markdown-it": "^14.1.0",
-        "openapi-diff-node": "^1.0.1"
+        "openapi-diff-node": "1.1.0"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -5862,9 +5862,9 @@
       }
     },
     "node_modules/openapi-diff-node": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/openapi-diff-node/-/openapi-diff-node-1.0.1.tgz",
-      "integrity": "sha512-0pjsoRPMvK/SYM33HQ3obmopwrxw3IBk6YqhMK+dAA5Cy4JD6UCVp89KE1oG2Hs9b99AmznTsb7UD+eIXhrEFQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/openapi-diff-node/-/openapi-diff-node-1.1.0.tgz",
+      "integrity": "sha512-eolLUj8pnJmBhaKFVIOyvuy0p7/kZepRQAQAzSvR/tvUYIxGfYbuJsyhLB1PksY2cuhyDP9zYetLwbHJznA/ig=="
     },
     "node_modules/openapi-types": {
       "version": "12.1.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@actions/core": "^1.10.1",
     "@slack/web-api": "^7.3.1",
     "markdown-it": "^14.1.0",
-    "openapi-diff-node": "^1.0.1"
+    "openapi-diff-node": "1.1.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/src/locale/en-us.ts
+++ b/src/locale/en-us.ts
@@ -22,5 +22,9 @@ export const LOCALE_EN_US: Locale = {
 
   repository: 'Repository',
 
-  'exception.missing-description': 'No description provided. Please add one'
+  'exception.missing-description': 'No description provided. Please add one',
+
+  description: 'description',
+  required: 'required',
+  example: 'example'
 }

--- a/src/locale/ko-kr.ts
+++ b/src/locale/ko-kr.ts
@@ -22,5 +22,9 @@ export const LOCALE_KO_KR: Locale = {
 
   repository: '저장소',
 
-  'exception.missing-description': '설명이 없습니다. 추가해주세요'
+  'exception.missing-description': '설명이 없습니다. 추가해주세요',
+
+  description: '설명',
+  required: '필수여부',
+  example: '예시'
 }

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -237,6 +237,15 @@ export class Slack {
         ]
       }
 
+      let required = ''
+      if (param.required === true) {
+        required = translate('required.required')
+      } else if (param.required === false) {
+        required = translate('required.optional')
+      } else {
+        required = param.required
+      }
+
       const description: RichTextList = {
         type: 'rich_text_list',
         style: 'bullet',
@@ -260,7 +269,7 @@ export class Slack {
             elements: [
               {
                 type: 'text',
-                text: param.required ? 'Required' : 'Optional'
+                text: `필수여부: ${required}`
               }
             ]
           }

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -309,6 +309,26 @@ export class Slack {
         })
       }
 
+      if (param.changeLogs.length > 0) {
+        const changeLogElementList: RichTextElement[] = []
+
+        for (const changeLog of param.changeLogs) {
+          const { field, oldValue, newValue } = changeLog
+
+          changeLogElementList.push({
+            type: 'text',
+            text: `${field} ${translate(
+              'status.modified'
+            )}: ${oldValue} -> ${newValue}`
+          })
+        }
+
+        descriptionElements.push({
+          type: 'rich_text_section',
+          elements: changeLogElementList
+        })
+      }
+
       const description: RichTextList = {
         type: 'rich_text_list',
         style: 'bullet',

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -246,34 +246,75 @@ export class Slack {
         required = param.required
       }
 
+      const descriptionElements: RichTextList['elements'] = []
+
+      if (param.description) {
+        descriptionElements.push({
+          type: 'rich_text_section',
+          elements: [
+            {
+              type: 'text',
+              text: `${translate('description')}: ${param.description}`
+            }
+          ]
+        })
+      }
+
+      if (required !== 'N/A') {
+        descriptionElements.push({
+          type: 'rich_text_section',
+          elements: [
+            {
+              type: 'text',
+              text: `${translate('required')}: ${required}`
+            }
+          ]
+        })
+      }
+
+      if (param.example !== 'N/A') {
+        descriptionElements.push({
+          type: 'rich_text_section',
+          elements: [
+            {
+              type: 'text',
+              text: `${translate('example')}: ${param.example}`
+            }
+          ]
+        })
+      }
+
+      if (param.enum.length > 0) {
+        const enumElementList: RichTextElement[] = []
+
+        for (const e of param.enum) {
+          const isFirstIteration = enumElementList.length === 0
+
+          enumElementList.push({
+            type: 'text',
+            text: isFirstIteration ? 'ENUM: ' : ', '
+          })
+          enumElementList.push({
+            type: 'text',
+            text: e,
+            style: {
+              code: true
+            }
+          })
+        }
+
+        descriptionElements.push({
+          type: 'rich_text_section',
+          elements: enumElementList
+        })
+      }
+
       const description: RichTextList = {
         type: 'rich_text_list',
         style: 'bullet',
         indent: 0,
         border: 1,
-        elements: [
-          {
-            type: 'rich_text_section',
-            elements: [
-              {
-                type: 'text',
-                text:
-                  param.description ||
-                  translate('exception.missing-description')
-              }
-            ]
-          },
-
-          {
-            type: 'rich_text_section',
-            elements: [
-              {
-                type: 'text',
-                text: `필수여부: ${required}`
-              }
-            ]
-          }
-        ]
+        elements: descriptionElements
       }
 
       const newline: RichTextSection = {

--- a/src/types/locale.ts
+++ b/src/types/locale.ts
@@ -21,4 +21,8 @@ export interface Locale {
   repository: string
 
   'exception.missing-description': string
+
+  description: string
+  required: string
+  example: string
 }


### PR DESCRIPTION
# 0.3.0-beta (July 14, 2024)

Below is a list of all new features, APIs, deprecations, and breaking changes.

## New Features

* Enums and examples are now shown in slack messages. 
* Properties which are not available or not provided are not shown in slack messages to save space. 
* ChangeLogs will show a detailed diff of properties in fields. 

## Improvements

- None

## Other Changes

- openapi-diff-node `^1.0.1` -> `1.1.0`

## Bug Fixes

- Distinguish required field being not available (`N/A`) and being false. 
