### PR TITLE
Release/v0.3.2 beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@actions/core": "^1.10.1",
         "@slack/web-api": "^7.3.1",
         "markdown-it": "^14.1.0",
-        "openapi-diff-node": "1.1.0"
+        "openapi-diff-node": "2.0.0"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -5862,9 +5862,9 @@
       }
     },
     "node_modules/openapi-diff-node": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-diff-node/-/openapi-diff-node-1.1.0.tgz",
-      "integrity": "sha512-eolLUj8pnJmBhaKFVIOyvuy0p7/kZepRQAQAzSvR/tvUYIxGfYbuJsyhLB1PksY2cuhyDP9zYetLwbHJznA/ig=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/openapi-diff-node/-/openapi-diff-node-2.0.0.tgz",
+      "integrity": "sha512-afi99lJmxlm22tPQcwpn9AvG9QRoUQ6ncXOW+ROabJTuw9t6jjJaB+ese/p9ekZ5OONmqRuf9rwx3BRMnJQLOA=="
     },
     "node_modules/openapi-types": {
       "version": "12.1.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@actions/core": "^1.10.1",
     "@slack/web-api": "^7.3.1",
     "markdown-it": "^14.1.0",
-    "openapi-diff-node": "1.1.0"
+    "openapi-diff-node": "2.0.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/src/locale/en-us.ts
+++ b/src/locale/en-us.ts
@@ -30,5 +30,7 @@ export const LOCALE_EN_US: Locale = {
 
   'changed.before': 'Before',
   'changed.after': 'After',
-  'properties.changed': 'Properties changed'
+  'properties.changed': 'Properties changed',
+
+  'empty.array': 'Not specified'
 }

--- a/src/locale/en-us.ts
+++ b/src/locale/en-us.ts
@@ -26,5 +26,9 @@ export const LOCALE_EN_US: Locale = {
 
   description: 'description',
   required: 'required',
-  example: 'example'
+  example: 'example',
+
+  'changed.before': 'Before',
+  'changed.after': 'After',
+  'properties.changed': 'Properties changed'
 }

--- a/src/locale/ko-kr.ts
+++ b/src/locale/ko-kr.ts
@@ -30,5 +30,7 @@ export const LOCALE_KO_KR: Locale = {
 
   'changed.before': '변경 전',
   'changed.after': '변경 후',
-  'properties.changed': '변경된 속성'
+  'properties.changed': '변경된 속성',
+
+  'empty.array': '없음'
 }

--- a/src/locale/ko-kr.ts
+++ b/src/locale/ko-kr.ts
@@ -26,5 +26,9 @@ export const LOCALE_KO_KR: Locale = {
 
   description: '설명',
   required: '필수여부',
-  example: '예시'
+  example: '예시',
+
+  'changed.before': '변경 전',
+  'changed.after': '변경 후',
+  'properties.changed': '변경된 속성'
 }

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -78,6 +78,7 @@ export class Slack {
     diff: DiffOutputItem
   ): Promise<SendEndpointReturnType> {
     const endpoint = `${diff.method.toUpperCase()}: ${diff.path}`
+    const description = diff.description
 
     const changedParameters = this._getUnchangedItems(diff.queryParams)
     const changedRequestBody = this._getUnchangedItems(diff.requestBody)
@@ -149,6 +150,10 @@ export class Slack {
                 {
                   type: 'mrkdwn',
                   text: `*${translate('endpoint.singular')}:*\n ${endpoint}`
+                },
+                {
+                  type: 'mrkdwn',
+                  text: `*${translate('description')}:*\n ${description}`
                 },
                 {
                   type: 'mrkdwn',

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -320,11 +320,22 @@ export class Slack {
         for (const changeLog of param.changeLogs) {
           const { field, oldValue, newValue } = changeLog
 
+          let oldValueText = oldValue
+          let newValueText = newValue
+
+          if (Array.isArray(oldValue)) {
+            oldValueText = oldValue.join(', ')
+          }
+
+          if (Array.isArray(newValue)) {
+            newValueText = newValue.join(', ')
+          }
+
           changeLogElementList.push({
             type: 'text',
             text: `${field} ${translate(
               'status.modified'
-            )}: ${oldValue} -> ${newValue}`
+            )}: ${oldValueText} -> ${newValueText}`
           })
         }
 

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -314,11 +314,47 @@ export class Slack {
         })
       }
 
+      const changeLogElementList: RichTextList[] = []
+
       if (param.changeLogs.length > 0) {
-        const changeLogElementList: RichTextElement[] = []
+        changeLogElementList.push({
+          type: 'rich_text_list',
+          style: 'bullet',
+          indent: 0,
+          border: 1,
+          elements: [
+            {
+              type: 'rich_text_section',
+              elements: [
+                {
+                  type: 'text',
+                  text: translate('properties.changed')
+                }
+              ]
+            }
+          ]
+        })
 
         for (const changeLog of param.changeLogs) {
           const { field, oldValue, newValue } = changeLog
+
+          changeLogElementList.push({
+            type: 'rich_text_list',
+            style: 'bullet',
+            indent: 1,
+            border: 1,
+            elements: [
+              {
+                type: 'rich_text_section',
+                elements: [
+                  {
+                    type: 'text',
+                    text: field
+                  }
+                ]
+              }
+            ]
+          })
 
           let oldValueText = oldValue
           let newValueText = newValue
@@ -332,17 +368,32 @@ export class Slack {
           }
 
           changeLogElementList.push({
-            type: 'text',
-            text: `${field} ${translate(
-              'status.modified'
-            )}: ${oldValueText} -> ${newValueText}`
+            type: 'rich_text_list',
+            style: 'bullet',
+            indent: 2,
+            border: 1,
+            elements: [
+              {
+                type: 'rich_text_section',
+                elements: [
+                  {
+                    type: 'text',
+                    text: `${translate('changed.before')}: \n${oldValueText}`
+                  }
+                ]
+              },
+              {
+                type: 'rich_text_section',
+                elements: [
+                  {
+                    type: 'text',
+                    text: `${translate('changed.after')}: \n${newValueText}`
+                  }
+                ]
+              }
+            ]
           })
         }
-
-        descriptionElements.push({
-          type: 'rich_text_section',
-          elements: changeLogElementList
-        })
       }
 
       const description: RichTextList = {
@@ -365,6 +416,11 @@ export class Slack {
 
       elements.push(statusAndEndpoint)
       elements.push(description)
+
+      if (changeLogElementList.length > 0) {
+        elements.push(...changeLogElementList)
+      }
+
       elements.push(newline)
     }
 

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -360,11 +360,19 @@ export class Slack {
           let newValueText = newValue
 
           if (Array.isArray(oldValue)) {
-            oldValueText = oldValue.join(', ')
+            if (oldValue.length > 0) {
+              oldValueText = oldValue.join(', ')
+            } else {
+              oldValueText = `(${translate('empty.array')})`
+            }
           }
 
           if (Array.isArray(newValue)) {
-            newValueText = newValue.join(', ')
+            if (newValue.length > 0) {
+              newValueText = newValue.join(', ')
+            } else {
+              newValueText = `(${translate('empty.array')})`
+            }
           }
 
           changeLogElementList.push({

--- a/src/types/locale.ts
+++ b/src/types/locale.ts
@@ -25,4 +25,8 @@ export interface Locale {
   description: string
   required: string
   example: string
+
+  'changed.before': string
+  'changed.after': string
+  'properties.changed': string
 }

--- a/src/types/locale.ts
+++ b/src/types/locale.ts
@@ -29,4 +29,6 @@ export interface Locale {
   'changed.before': string
   'changed.after': string
   'properties.changed': string
+
+  'empty.array': string
 }


### PR DESCRIPTION
# 0.3.2-beta (July 24, 2024)

Below is a list of all new features, APIs, deprecations, and breaking changes.

## New Features

- Descriptions of API endpoints are now shown in main message.  (Thanks to [openapi-diff-node v2.0.0](https://www.npmjs.com/package/openapi-diff-node/v/2.0.0))

## Improvements

- Arrays in schemas (in both parameters AND request/response bodies) are now displayed with improved readability. This works particularly well with ENUMs, in which possible values of are provided as an array. 

## Other Changes

- openapi-diff-node upgraded from v1.1.0 to v2.0.0


