### PR TITLE
Release/v0.3.3-beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@actions/core": "^1.10.1",
         "@slack/web-api": "^7.3.1",
         "markdown-it": "^14.1.0",
-        "openapi-diff-node": "^2.1.0"
+        "openapi-diff-node": "2.1.0"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@actions/core": "^1.10.1",
         "@slack/web-api": "^7.3.1",
         "markdown-it": "^14.1.0",
-        "openapi-diff-node": "2.0.0"
+        "openapi-diff-node": "^2.1.0"
       },
       "devDependencies": {
         "@jest/globals": "^29.7.0",
@@ -5862,9 +5862,9 @@
       }
     },
     "node_modules/openapi-diff-node": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/openapi-diff-node/-/openapi-diff-node-2.0.0.tgz",
-      "integrity": "sha512-afi99lJmxlm22tPQcwpn9AvG9QRoUQ6ncXOW+ROabJTuw9t6jjJaB+ese/p9ekZ5OONmqRuf9rwx3BRMnJQLOA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/openapi-diff-node/-/openapi-diff-node-2.1.0.tgz",
+      "integrity": "sha512-BvDsvcTFoicGJUJqH8rgKAk9rgoGxE1+CTsT9prt4sC+P9RX9/6VMO7RcE8CX8I+vKnP+gAxdB27z7ZH11nyIA=="
     },
     "node_modules/openapi-types": {
       "version": "12.1.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@actions/core": "^1.10.1",
     "@slack/web-api": "^7.3.1",
     "markdown-it": "^14.1.0",
-    "openapi-diff-node": "2.0.0"
+    "openapi-diff-node": "^2.1.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@actions/core": "^1.10.1",
     "@slack/web-api": "^7.3.1",
     "markdown-it": "^14.1.0",
-    "openapi-diff-node": "^2.1.0"
+    "openapi-diff-node": "2.1.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",


### PR DESCRIPTION
# 0.3.3-beta (July 24, 2024)

Below is a list of all new features, APIs, deprecations, and breaking changes.

## Improvements

- update openapi-diff-node to v2.1.0 (use summary as a fallback when description is empty)

## Other Changes

- openapi-diff-node upgraded from v2.0.0 to v2.1.0